### PR TITLE
Replace getargspec with getfullargspec

### DIFF
--- a/src/pymake3/core/target.py
+++ b/src/pymake3/core/target.py
@@ -74,7 +74,7 @@ class Target(object):
         os.chdir(cwd)
 
     def __call(self, func, conf):
-        argspec = inspect.getargspec(func)
+        argspec = inspect.getfullargspec(func)
         accepts_kwargs = len(argspec.args) > 1 and argspec.defaults is not None
 
         if accepts_kwargs:


### PR DESCRIPTION
Hi,

getargspec was depreacted and removed in 3.11

Could you fix this and release 0.0.3?

Thx :)